### PR TITLE
phabricator: Create extension to save Bugzilla Bug ID (bug: 1361649)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Mozilla Phabricator extensions
+
+To test follow "Testing simple extensions (DifferentialBugId*)"
+https://docs.google.com/a/mozilla.com/document/d/1cMzb0MOcBrvGu5IhIJAMcudZHSD_GzVygxWMsjJo4q0/edit?usp=sharing

--- a/extensions/differential/customfield/DifferentialBugzillaBugIDCommitMessageField.php
+++ b/extensions/differential/customfield/DifferentialBugzillaBugIDCommitMessageField.php
@@ -1,0 +1,59 @@
+<?php
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/**
+ * Extends Commit Message with a 'Bugzilla Bug ID' field.
+ */
+final class DifferentialBugzillaBugIDCommitMessageField
+  extends DifferentialCommitMessageCustomField {
+
+  // returned with
+  // `DifferentialCommitMessageField::getCommitMessageFieldKey`
+  // to provide error messages
+  // and then in `DifferentialCommitMessageParser::setCommitMessageFields`
+  // to prepare the fields and then save in
+  // `DifferentialRevisionTransactionType`
+  const FIELDKEY = 'bugzilla.bug-id';
+
+  /* -- Commit Message Field descriptions ---------------------------- */
+
+  public function getFieldName() {
+    return pht('Bug');
+  }
+
+  public function getCustomFieldKey() {
+    // Link to DifferentialBugzillaBugIDField.
+    return 'differential:bugzilla-bug-id';
+  }
+
+  // Should Label appear in Arcanist message
+  public function isFieldEditable() {
+    return true;
+  }
+
+  public function getFieldAliases() {
+    // Possible alternative labels to be parsed for in CVS or Arcanist
+    // commit message.
+    return array(
+      'Bugzilla Bug ID',
+      'Bugzilla',
+    );
+  }
+
+  /* -- Parsing commits --------------------------------------------- */
+
+  public function validateFieldValue($value) {
+    if (!strlen($value) or !$value) {
+      $this->raiseValidationException(
+        pht('You need to provide a Bugzilla Bug ID'));
+    }
+    if (!ctype_digit($value)) {
+      $this->raiseValidationException(
+        pht('Bugzilla Bug ID should consist of all digits'));
+    }
+    // TODO validate if a public bug with given id exists in Bugzilla.
+    return $value;
+  }
+}

--- a/extensions/differential/customfield/DifferentialBugzillaBugIDField.php
+++ b/extensions/differential/customfield/DifferentialBugzillaBugIDField.php
@@ -1,0 +1,146 @@
+<?php
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/**
+ * Extends Differential with a 'Bugzilla Bug ID' field.
+ */
+final class DifferentialBugzillaBugIDField
+  extends DifferentialStoredCustomField {
+
+  // Used in application transaction validation
+  private $error;
+
+/* -(  Core Properties and Field Identity  )--------------------------------- */
+
+  public function getFieldKey() {
+    return 'differential:bugzilla-bug-id';
+  }
+
+  public function getFieldName() {
+    return pht('Bugzilla Bug ID');
+  }
+
+  public function getFieldKeyForConduit() {
+    // Link to DifferentialBugzillaBugIDCommitMessageField
+    return 'bugzilla.bug-id';
+  }
+
+  public function getFieldDescription() {
+    // Rendered in 'Config > Differential > differential.fields'
+    return pht('Displays associated Bugzilla Bug ID.');
+  }
+
+  public function isFieldEnabled() {
+    return true;
+  }
+
+  public function canDisableField() {
+    // Field can't be switched off in configuration
+    return false;
+  }
+
+/* -(  ApplicationTransactions  )-------------------------------------------- */
+
+  public function shouldAppearInApplicationTransactions() {
+    // Required to be editable
+    return true;
+  }
+
+/* -(  Edit View  )---------------------------------------------------------- */
+
+  public function shouldAppearInEditView() {
+    // Should the field appear in Edit Revision feature
+    // If set to false value will not be read from Arcanist commit message.
+    // ERR-CONDUIT-CORE: Transaction with key "6" has invalid type
+    // "bugzilla.bug-id". This type is not recognized. Valid types are: update,
+    // [...]
+    return true;
+  }
+
+  public function readValueFromRequest(AphrontRequest $request) {
+    $this->setValue($request->getStr($this->getFieldKey()));
+  }
+
+  public function renderEditControl(array $handles) {
+    // TODO add validation
+    return id(new AphrontFormTextControl())
+      ->setLabel($this->getFieldName())
+      ->setCaption(
+        pht('Example: %s', phutil_tag('tt', array(), '2345')))
+      ->setName($this->getFieldKey())
+      ->setValue($this->getValue(), '')
+      ->setError($this->error);
+  }
+
+/* -(  Property View  )------------------------------------------------------ */
+
+  public function shouldAppearInPropertyView() {
+    // Should bug id be visible in Differential UI.
+    return true;
+  }
+
+  public function renderPropertyViewValue(array $handles) {
+    // TODO Link to the right Bugzilla server (defined in docker)
+    return phutil_tag(
+      'a', array('href' => 'https://bugzilla/'.$this->getValue()),
+      $this->getValue()
+    );
+  }
+
+/* -(  List View  )---------------------------------------------------------- */
+
+  // Switched of as renderOnListItem is undefined
+  // public function shouldAppearInListView() {
+  //   return true;
+  // }
+
+  // TODO Find out if/how to implement renderOnListItem
+  // It throws Incomplete if not overriden, but doesn't appear anywhere else
+  // except of it's definition in `PhabricatorCustomField`
+
+/* -(  Global Search  )------------------------------------------------------ */
+
+  public function shouldAppearInGlobalSearch() {
+    return true;
+  }
+
+/* -(  Conduit  )------------------------------------------------------------ */
+
+  public function shouldAppearInConduitDictionary() {
+    // Should the field appear in `differential.revision.search`
+    return true;
+  }
+
+  public function shouldAppearInConduitTransactions() {
+    // Required if needs to be saved via Conduit (i.e. from `arc diff`)
+    return true;
+  }
+
+  protected function newConduitSearchParameterType() {
+    return new ConduitStringParameterType();
+  }
+
+  protected function newConduitEditParameterType() {
+    // Define the type of the parameter for Conduit
+    return new ConduitStringParameterType();
+  }
+
+  public function readFieldValueFromConduit(string $value) {
+    return $value;
+  }
+
+  public function isFieldEditable() {
+    // Has to be editable to be written from `arc diff`
+    return true;
+  }
+
+  public function shouldDisableByDefault() {
+    return false;
+  }
+
+  public function shouldOverwriteWhenCommitMessageIsEdited() {
+    return true;
+  }
+}

--- a/extensions/differential/customfield/__tests__/DifferentialBugzillaIdCustomFieldTestCase.php
+++ b/extensions/differential/customfield/__tests__/DifferentialBugzillaIdCustomFieldTestCase.php
@@ -1,0 +1,55 @@
+<?php
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+final class DifferentialBugzillaBugIDCustomFieldTestCase
+  extends PhabricatorTestCase {
+
+  public function testBugIdCommitMessageFieldValidation() {
+    $test = array(
+      'false' => array(null, '', '12.3', '1e3'),
+      'true' => array('123')
+    );
+
+    $field = new DifferentialBugzillaBugIDCommitMessageField();
+    foreach ($test as $success => $ids) {
+      foreach ($ids as $value) {
+        $caught = false;
+        try {
+          $result = $field->validateFieldValue($value);
+        } catch (DifferentialFieldValidationException $ex) {
+          $caught = $ex;
+        }
+        if ($success == 'false') {
+          $this->assertTrue(
+            ($caught instanceof DifferentialFieldValidationException));
+        } else {
+          $this->assertEqual($result, $value);
+        }
+      }
+    }
+  }
+
+  public function testBugIdPropertyViewRendering() {
+    $field = new DifferentialBugzillaBugIDField();
+    $field->setValue('123');
+    $this->assertEqual(
+      $field->renderPropertyViewValue(array())->getHTMLContent(),
+      '<a href="https://bugzilla/123" rel="noreferrer">123</a>'
+    );
+  }
+
+  public function testLinkBetweenCommitMessageAndCustomField() {
+    $cm_field = new DifferentialBugzillaBugIDCommitMessageField();
+    $custom_field = new DifferentialBugzillaBugIDField();
+    $this->assertEqual(
+      $cm_field->getCustomFieldKey(),
+      $custom_field->getFieldKey()
+    );
+    $this->assertEqual(
+      $custom_field->getFieldKeyForConduit(),
+      DifferentialBugzillaBugIDCommitMessageField::FIELDKEY
+    );
+  }
+}


### PR DESCRIPTION
Two classes are created extending `DifferentialCommitMessageCustomField`
and `DifferentialStoredCustomField`. Bug id provided in `arc diff`
message is required and validated.