### PR TITLE
Add Conduit API method for retrieving a user PHID from a BMO ID

### DIFF
--- a/conduit/BMOExternalAccountSearchConduitAPIMethod.php
+++ b/conduit/BMOExternalAccountSearchConduitAPIMethod.php
@@ -1,0 +1,40 @@
+<?php
+
+final class BMOExternalAccountSearchConduitAPIMethod
+  extends UserConduitAPIMethod {
+
+  public function getAPIMethodName() {
+    return 'bmoexternalaccount.search';
+  }
+
+  public function getMethodDescription() {
+    return pht('Retrieve external user PHID data based on BMO ID.');
+  }
+
+  public function defineParamTypes() {
+    return array('accountids' => 'required list<string>');
+  }
+
+  protected function defineReturnType() {
+    return 'nonempty dict<string, wild>';
+  }
+
+  protected function execute(ConduitAPIRequest $request) {
+    $account_ids = $request->getValue('accountids');
+
+    $handles = id(new PhabricatorExternalAccountQuery())
+      ->setViewer($request->getUser())
+      ->withAccountIDs($account_ids)
+      ->execute();
+
+    $result = array();
+    foreach ($handles as $user => $handle) {
+      $result[] = array(
+        'id' => $handle->getAccountID(),  // The BMO ID
+        'phid' => $handle->getPHID()      // The Phabricator PHID
+      );
+    }
+
+    return $result;
+  }
+}


### PR DESCRIPTION
To test:

0.  Add this PHP file to the phabricator/src/extensions directory
1.  Log into Phabricator admin, create a conduit API key
2.  `docker-compose down && docker-compose up`
3.  cURL to your local phabricator to query for the external user:

```
curl http://phabricator.dev:7788/api/bmoexternalaccount.search -d api.token=YOUR_API_TOKEN -d accountids[]='1'
```

`1` is the user's Bugzilla user ID 

You should receive a response like this:

```
{"result":[{"id":"1","phid":"PHID-XXXXXXXXXXXXXXX"}],"error_code":null,"error_info":null}
```