### PR TITLE
Don't store API Key upon user creation.

### DIFF
--- a/auth/PhabricatorBMOAuthProvider.php
+++ b/auth/PhabricatorBMOAuthProvider.php
@@ -380,7 +380,6 @@ final class PhabricatorBMOAuthProvider extends PhabricatorAuthProvider {
 
     // Create or load the user account and refresh the page
     $account = $this->loadOrCreateAccount($user_json['id']);
-    $account->setProperty('api_key', $api_key);
 
     return array($account, $response);
   }


### PR DESCRIPTION
Mr. Cote says we shouldn't store API keys anymore.